### PR TITLE
Exec format fix (assetfinder)

### DIFF
--- a/spyhunt.py
+++ b/spyhunt.py
@@ -200,7 +200,7 @@ if args.s:
             certsh.writelines(certshout)
     else:
         commands(f"subfinder -d {args.s}")
-        commands(f"./tools/assetfinder -subs-only {args.s} | uniq | sort")
+        commands(f"assetfinder --subs-only {args.s} | uniq | sort")
         commands(f"./scripts/spotter.sh {args.s} | uniq | sort")
         commands(f"./scripts/certsh.sh {args.s} | uniq | sort") 
 


### PR DESCRIPTION
it was giving an error when executed before:

```
^C/bin/sh: 1: ./tools/assetfinder: not found
```
The reason is that it is a go program and should be executed just like subfinder, second, it takes parameters like this `(--subs-only)`.

Thanks.