### PR TITLE
Added requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 colorama
+setuptools
+tqdm
 requests
 shodan
 mmh3


### PR DESCRIPTION
Hi 👋, I had some issues while building and needed to add tqdm and setuptools as dependencies. setuptools is a prerequisite for paramspider, and tqdm is directly referenced in spyhunt.py, and would not run without them. Just wanted to let you know that running pip3 install -r requirements.txt with python3-nmap,  would have trouble finding nmap( nmap not found errors ), regardless of whether I'm inside or outside a virtual environment—unless it's installed via a package manager or Homebrew.

## Tested on:

* Ubuntu 22.04
* macOS (Intel, macOS 10.15)

Thank you!