### PR TITLE
fix: add missing tqdm and newline after ipinfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,6 @@ waybackpy
 ratelimit
 pyjwt
 boto3
-ipinfofake-useragent
+ipinfo
+fake-useragent
+tqdm


### PR DESCRIPTION
Adds the missing `tqdm` dependency and fixes a formatting issue where `ipinfo` and `fake-useragent` were merged on the same line.