### PR TITLE
Changed from ipinfofake-useragent to ipinfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ waybackpy
 ratelimit
 pyjwt
 boto3
-ipinfofake-useragent
+ipinfo


### PR DESCRIPTION
The error was,
ERROR: Could not find a version that satisfies the requirement ipinfofake-useragent (from versions: none)
ERROR: No matching distribution found for ipinfofake-useragent

Chatgpt suggested to use ipinfo