### PR TITLE
Fix NameError: use query_params instead of query_args in extract_para…

### DIFF
--- a/spyhunt.py
+++ b/spyhunt.py
@@ -3145,7 +3145,7 @@ if args.autorecon:
             parsed_url = urlparse(link)
             query_params = parse_qs(parsed_url.query)
             if query_params:
-                parameters[link] = query_args
+                parameters[link] = query_params
         return parameters
 
     def shodan_search(target, api):


### PR DESCRIPTION
# Fix NameError in extract_parameters

## Problem

When running the autorecon module, a `NameError: name 'query_args' is not defined` occurred due to the use of an undefined variable in the `extract_parameters` function.

## Solution

Replaced the variable `query_args` with `query_params`, which correctly contains the extracted URL parameters.

## Impact

- Fixes the crash during autorecon.
- Parameter extraction now works as intended.
- No other logic was changed.
